### PR TITLE
docs: Fix .clang-format file link to use root directory reference

### DIFF
--- a/docs/reading/clang-format/index.md
+++ b/docs/reading/clang-format/index.md
@@ -32,9 +32,9 @@
 
 ### 2-2. （方法1）下载示例文件
 
-[缩进采用 4 空格的.clang-format](clang-format/space.clang-format){download}
+[缩进采用 4 空格的.clang-format](/clang-format/space.clang-format){download}
 
-[缩进采用 Tab制表符 的.clang-format](clang-format/tab.clang-format){download}
+[缩进采用 Tab制表符 的.clang-format](/clang-format/tab.clang-format){download}
 
 两个下载文件均可，根据个人喜好自行选择。下载之后需要修改文件名：
 


### PR DESCRIPTION
# 改动

将 `.clang-format` 下载文件链接改为基于根目录的引用，确保文件可以正常访问。

在[上一个 PR](https://github.com/Tongji-High-level-Language-Programming/Website/pull/37)中，
下载链接返回 404。原因是链接未正确指向根目录，而 `public` 目录下的文件在构建时会被复制到输出目录的根路径。

我对此前的疏漏表示抱歉，在最终测试阶段未能及时发现该问题。

cc @Maoyao233