### PR TITLE
fix: use cache in `pnpm/action-setup` instead of `actions/setup-node` to fix broken workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,18 +30,20 @@ jobs:
           fetch-depth: 0 # 如果未启用 lastUpdated，则不需要
       - name: Checkout LFS objects
         run: git lfs checkout
-      - uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: pnpm # 或 npm / yarn
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Install dependencies
-        run: pnpm install # 或 npm ci / yarn install / bun install
+        run: pnpm install
       - name: Build with VitePress
-        run: pnpm docs:build # 或 npm run docs:build / yarn docs:build / bun run docs:build
+        run: pnpm docs:build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
不确定为什么会坏，似乎是两个 action 使用了不同的 node 版本导致的兼容性问题；想要尝试 `action-setup` 的 standalone 选项，不过首先尝试让这两个 action 耦合更低一点，发现直接成功了。